### PR TITLE
Permit toggling of default Apache vhost creation

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class mediawiki::params {
   $tarball_url        = 'http://download.wikimedia.org/mediawiki/1.19/mediawiki-1.19.1.tar.gz'
   $conf_dir           = '/etc/mediawiki'
   $apache_daemon      = '/usr/sbin/apache2'
+  $default_vhost      = true
   $installation_files = ['api.php',
                          'api.php5',
                          'bin',


### PR DESCRIPTION
In the event of running a MediaWiki instance on a nonstandard port and a
reverse proxy on port 80, both on the same host, you need to not have
Apache listening on port 80.  Unfortunately, simply passing the
default_vhost parameter causes a dependency cycle :( so there are some
hackish fixes for that problem.
