### PR TITLE
Ubuntu requires mpm_module => prefork

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,7 +58,9 @@ class mediawiki (
   Class['mysql::server'] -> Class['mediawiki']
   Class['mysql::config'] -> Class['mediawiki']
   
-  class { 'apache': }
+  class { 'apache':
+    mpm_module => 'prefork',
+  }
   class { 'apache::mod::php': }
   
   


### PR DESCRIPTION
`apache::mod::php` now required that apache is called with `mpm_module=> prefork`  for those operating systems that don 't do this by default (like Debian/Ubuntu)
